### PR TITLE
Compute group selection via selectedItems (Omnitable multi select)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
 	"name": "cosmoz-grouped-list",
 	"main": "cosmoz-grouped-list.html",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"homepage": "https://github.com/Neovici/cosmoz-grouped-list",
 	"authors": [
 		"Neovici Development"

--- a/cosmoz-grouped-list.js
+++ b/cosmoz-grouped-list.js
@@ -58,7 +58,7 @@
 		observers: [
 			'_dataChanged(data.*)',
 			'_scrollTargetChanged(scrollTarget, _isAttached)',
-			'_selectedItemsChanged(selectedItems.*)'
+			'_selectedItemsChanged(selectedItems.splices)'
 		],
 
 		/**
@@ -437,6 +437,13 @@
 			this._changeItemSelection(item, true);
 		},
 
+		selectItems(items) {
+			if (!items || !Array.isArray(items)) {
+				return;
+			}
+			items.forEach(i => this.selectItem(i));
+		},
+
 		highlightItem(item, reverse) {
 			const model = this._getModelFromItem(item),
 				highlightedIndex = this.highlightedItems.indexOf(item);
@@ -465,6 +472,7 @@
 		isItemHighlighted(item) {
 			return this.highlightedItems.indexOf(item) >= 0;
 		},
+
 		/**
 		 * Selects/Deselects an group without its items.
 		 * @param {Object} group - The group.
@@ -639,10 +647,7 @@
 			if (!group || !group.items) {
 				return;
 			}
-			return group.items.every(item => {
-				const model = this._getModelFromItem(item);
-				return model && model['selected'];
-			});
+			return group.items.every(item => this.isItemSelected(item));
 		},
 
 		_selectedItemsChanged() {
@@ -652,6 +657,7 @@
 		_debounceValidateGroupSelectionState() {
 			this.debounce('_validateGroupSelectionState', this._validateGroupSelectionState, 10);
 		},
+
 		/**
 		 * Selects a group if all items of a group are selected.
 		 * Deselects a group if not all items of a group are selected.
@@ -662,9 +668,12 @@
 			if (!groupState) {
 				return;
 			}
-			this.selectedItems.forEach(item => {
-				const group = this._getGroupOfItem(item);
-				this._changeGroupSelection(group, this._allGroupItemsSelected(group));
+
+			const groups = [...new Set(this.selectedItems.map(item => this._getGroupOfItem(item)))];
+
+			groups.forEach(group => {
+				const select = this._allGroupItemsSelected(group);
+				this._changeGroupSelection(group, select);
 			});
 		},
 	});

--- a/cosmoz-grouped-list.js
+++ b/cosmoz-grouped-list.js
@@ -465,7 +465,12 @@
 		isItemHighlighted(item) {
 			return this.highlightedItems.indexOf(item) >= 0;
 		},
-
+		/**
+		 * Selects/Deselects an group without its items.
+		 * @param {Object} group - The group.
+		 * @param {Boolean} select - True if the group should get selected.
+		 * @returns {undefined}
+		 */
 		_changeGroupSelection(group, select) {
 			const model = this._getModelFromItem(group),
 				groupState = this._groupsMap && this._groupsMap.get(group);
@@ -478,7 +483,12 @@
 				model['selected'] = select ? true : false;
 			}
 		},
-
+		/**
+		 * Selects/Deselects items of a group.
+		 * @param {Object} group - The group.
+		 * @param {Boolean} select - True if the group items should get selected.
+		 * @returns {undefined}
+		 */
 		_changeGroupItemsSelection(group, select) {
 			if (!group || !group.items) {
 				return;
@@ -584,20 +594,20 @@
 		/**
 		 * Selects/Deselects an item.
 		 * @param {Object} item - The item.
-		 * @param {Boolean} state - True if the item should get selected.
+		 * @param {Boolean} select - True if the item should get selected.
 		 * @returns {undefined}
 		 */
-		_changeItemSelection(item, state) {
+		_changeItemSelection(item, select) {
 			const model = this._getModelFromItem(item);
-			const setModelState = () => model && (model['selected'] = state);
+			const setModelState = () => model && (model['selected'] = select);
 
-			if (state && !this.isItemSelected(item)) {
+			if (select && !this.isItemSelected(item)) {
 				this.push('selectedItems', item);
 				setModelState();
 				return;
 			}
 
-			if (state) {
+			if (select) {
 				return;
 			}
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -193,9 +193,11 @@
 					element.deselectItem(item);
 
 					flush(() => {
-						assert.isFalse(element.isGroupSelected(group));
 						assert.equal(element.selectedItems.length, 1);
-						done();
+						setTimeout(() => {
+							assert.isFalse(element.isGroupSelected(group));
+							done();
+						}, 100);
 					});
 				});
 			});

--- a/test/basic.html
+++ b/test/basic.html
@@ -100,8 +100,10 @@
 			});
 
 			test('attaches cosmoz-grouped-list-template-selector', () => {
-				assert.equal(element._templateSelectors.length, 6);
-				assert.isTrue(element.hasRenderedData);
+				flush(() => {
+					assert.equal(element._templateSelectors.length, 6);
+					assert.isTrue(element.hasRenderedData);
+				});
 			});
 
 			test('top level items are groups', () => {
@@ -131,6 +133,22 @@
 					assert.equal(element.selectedItems.length, 1);
 					assert.equal(element.selectedItems[0], item);
 					assert.isTrue(element._getModelFromItem(item).selected);
+					done();
+				});
+			});
+
+			test('selects items', done => {
+				const items = [groups[0].items[0], groups[1].items[0]];
+				element.selectItems(items);
+				flush(() => {
+					const assertItem = item => {
+						assert.isTrue(element.isItemSelected(item));
+						assert.isTrue(element._getModelFromItem(item).selected);
+					};
+					items.forEach(item => assertItem(item));
+
+					assert.equal(element.selectedItems.length, items.length);
+					assert.equal(element.selectedItems[0], items[0]);
 					done();
 				});
 			});


### PR DESCRIPTION
Preparation for Omnitable's multi range select PR.

- compute group selection via selectedItems

Please release version `1.0.3`.

See https://github.com/Neovici/cosmoz-omnitable/pull/188
