### PR TITLE
Workaround for z-index issue in iron-list (#23)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,7 +32,10 @@
 		"iron-demo-helpers": "PolymerElements/iron-demo-helpers#1 - 2",
 		"iron-test-helpers": "PolymerElements/iron-test-helpers#1 - 2",
 		"web-component-tester": "^6.0.0",
-		"webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
+		"webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0",
+		"paper-dropdown-menu": "PolymerElements/paper-dropdown-menu#1 - 2",
+		"paper-listbox": "PolymerElements/paper-listbox#1 - 2",
+		"paper-item": "PolymerElements/paper-item#1 - 2"
 	},
 	"variants": {
 		"1.x": {

--- a/cosmoz-grouped-list-template-selector.html
+++ b/cosmoz-grouped-list-template-selector.html
@@ -8,6 +8,11 @@
 			:host ::slotted([hidden]) {
 				display: none !important;
 			}
+
+			/* This will give a row with an opened dropdown a z-index higher than all other rows */
+			:host(.has-dropdown) {
+				z-index: 100;
+			}
 		</style>
 		<slot></slot>
 	</template>
@@ -36,6 +41,19 @@
 
 			created() {
 				this.elements = {};
+			},
+
+			ready() {
+				// HACK(pasleq) Because iron-list uses `translate3d` transform on row template instances,
+				// a new stacking context is created for each row, preventing a dropdown to overflow the rows beneath.
+				// In order to workaround this issue, increase the z-index of the row if it has an opened dropdown
+				this.listen(this, 'paper-dropdown-open', '_onDropdownOpen');
+				this.listen(this, 'paper-dropdown-close', '_onDropdownClose');
+			},
+
+			detached() {
+				this.unlisten(this, 'paper-dropdown-open', '_onDropdownOpen');
+				this.unlisten(this, 'paper-dropdown-close', '_onDropdownClose');
 			},
 
 			show(element, templateId) {
@@ -74,6 +92,14 @@
 
 				this.groupedList.selectorItemChanged(this, newItem);
 			},
+
+			_onDropdownOpen(event) { // eslint-disable-line
+				this.classList.add('has-dropdown');
+			},
+
+			_onDropdownClose(event) { // eslint-disable-line
+				this.classList.remove('has-dropdown');
+			}
 		});
 	</script>
 </dom-module>

--- a/demo/helpers/demo-full.html
+++ b/demo/helpers/demo-full.html
@@ -5,6 +5,9 @@
 
 <link rel="import" href="../../../iron-icons/iron-icons.html" />
 <link rel="import" href="../../../iron-icon/iron-icon.html" />
+<link rel="import" href="../../../paper-dropdown-menu/paper-dropdown-menu-light.html" />
+<link rel="import" href="../../../paper-listbox/paper-listbox.html" />
+<link rel="import" href="../../../paper-item/paper-item.html" />
 
 <link rel="import" href="./demo-list-behavior.html" />
 <link rel="import" href="../../cosmoz-grouped-list.html" />
@@ -88,6 +91,14 @@
 								<div>Highlighted: <span>[[highlighted]]</span></div>
 							</div>
 							<div on-tap="select">Selected: <span>{{ selected }}</span> (click to select/deselect)</div>
+							<paper-dropdown-menu-light no-animations label="dropdown menu">
+								<paper-listbox slot="dropdown-content">
+									<paper-item>Item 1</paper-item>
+									<paper-item>Item 2</paper-item>
+									<paper-item>Item 3</paper-item>
+									<paper-item>Item 4</paper-item>
+								</paper-listbox>
+							</paper-dropdown-menu-light>
 							<div on-tap="toggleCollapse">[+]</div>
 							<div class$="{{_computeExtraContentClass(expanded)}}">
 								Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed quis posuere turpis, quis commodo neque. Aenean dapibus consequat dolor, et vestibulum enim volutpat a. Donec vel dui at diam tristique condimentum dapibus ac elit. Sed consequat nibh id nibh posuere egestas. Phasellus blandit convallis tellus, nec pharetra orci viverra ut. In at arcu consectetur, tempus velit sit amet, congue diam. Suspendisse potenti. In ac tristique nulla, quis elementum nisi.


### PR DESCRIPTION
Listen to dropdown open/close event in each row template instance, and increase z-index when a rows has an opened dropdown. Fixes #23