### PR TITLE
(patch) Select all items does not bring up the bottom bar

### DIFF
--- a/cosmoz-grouped-list.js
+++ b/cosmoz-grouped-list.js
@@ -544,10 +544,11 @@
 		 * @returns {void}
 		 */
 		selectAll() {
-			const selected = this.data.reduce((all, group) =>  {
-				const state = this._getItemState(group);
+			const selected = this.data.reduce((all, item) =>  {
+				const state = this._getItemState(item);
 				state.selected = true;
-				return all.concat(group.items || []);
+				// select both groups and flat items
+				return all.concat(item.items || item);
 			}, []);
 			this.splice.apply(this, ['selectedItems', 0, this.selectedItems.length].concat(selected));
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -133,6 +133,20 @@
 					done();
 				});
 			});
+
+			test('select all items [#977]', () => {
+				const allItems = items.slice();
+				element.selectAll();
+
+				assert.isTrue(element.isItemSelected(allItems[0]));
+				assert.isTrue(element.isItemSelected(allItems[1]));
+				assert.isTrue(element.isItemSelected(allItems[2]));
+
+				assert.equal(element.selectedItems.length, 3);
+				assert.equal(element.selectedItems[0], allItems[0]);
+				assert.equal(element.selectedItems[1], allItems[1]);
+				assert.equal(element.selectedItems[2], allItems[2]);
+			});
 		});
 
 		suite('empty-groups', () => {


### PR DESCRIPTION
When data is not grouped, `selectAll` only updates the internal state of the items as selected, but does not update selectedItems correctly.

Added regression test.

Fixes Neovici/cosmoz-frontend#977