### PR TITLE
Avoid resetting selectedItems to new empty array

### DIFF
--- a/cosmoz-grouped-list.js
+++ b/cosmoz-grouped-list.js
@@ -270,8 +270,11 @@ export class CosmozGroupedList extends templatizing(PolymerElement) {
 			return acc;
 		}, []);
 
-		// keep selected items accross data updates
-		this.selectedItems = this.selectedItems.filter(i => flatData.includes(i));
+		// keep selected items across data updates
+		const oldSelected = this.selectedItems.filter(i => flatData.includes(i));
+		if (oldSelected.length > 0) {
+			this.selectedItems = oldSelected;
+		}
 
 		return flatData;
 	}


### PR DESCRIPTION
- When component is constructed, selectedItems is set to []
- When preparing data, selectedItem tries to retain previous selection
  if possible
-- This causes a "normal" startup to set selectedItems to [] twice,
   which notifies twice and make any user act twice on the change.

This change makes selectedItems only set if the selection retention
actually finds something.

Signed-off-by: Patrik Kullman <patrik.kullman@neovici.se>