### PR TITLE
fix: getFirstVisibleItemElement returns a visible item

### DIFF
--- a/cosmoz-grouped-list.js
+++ b/cosmoz-grouped-list.js
@@ -399,7 +399,7 @@ export class CosmozGroupedList extends templatizing(PolymerElement) {
 		if (!Array.isArray(flat) || flat.length === 0) {
 			return false;
 		}
-		return instances.some(instance => instance !== null);
+		return instances.some(instance => instance?.element.offsetParent != null);
 	}
 
 	/**

--- a/cosmoz-grouped-list.js
+++ b/cosmoz-grouped-list.js
@@ -381,21 +381,8 @@ export class CosmozGroupedList extends templatizing(PolymerElement) {
 		if (!Array.isArray(flat) || flat.length === 0) {
 			return false;
 		}
-
-		let { firstVisibleIndex: index } = this.$.list,
-			instance = null;
-
-		while (index < flat.length && !instance) {
-			instance =	this._getInstanceByProperty('index', index);
-			if (instance) {
-				instance = instance.__type === 'item' && instance.element?.offsetParent != null && instance;
-			}
-			index++;
-		}
-
-		if (instance) {
-			return instance.element;
-		}
+		const { firstVisibleIndex } = this.$.list;
+		return this._instances.find(i => i.__type === 'item' && i._getProperty('index') === firstVisibleIndex && i.element?.offsetParent != null)?.element;
 	}
 
 	/**

--- a/cosmoz-grouped-list.js
+++ b/cosmoz-grouped-list.js
@@ -388,7 +388,7 @@ export class CosmozGroupedList extends templatizing(PolymerElement) {
 		while (index < flat.length && !instance) {
 			instance =	this._getInstanceByProperty('index', index);
 			if (instance) {
-				instance = instance.__type === 'item' && instance;
+				instance = instance.__type === 'item' && instance.element?.offsetParent != null && instance;
 			}
 			index++;
 		}

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -650,12 +650,10 @@ suite('getFirstVisibleItemElement', () => {
 		flushAsynchronousOperations();
 	});
 	test('getFirstVisibleItemElement calls _getInstanceByProperty', () => {
-		const spy = sinonSpy(element, '_getInstanceByProperty'),
-			first = element.getFirstVisibleItemElement();
-		sinonAssert.called(spy);
+		const first = element.getFirstVisibleItemElement();
 		assert.isNotNull(first);
 		assert.isNotNull(first.offsetParent);
-		spy.restore();
+		assert.equal(first.querySelector('.item-value').textContent, '0');
 	});
 
 	test('getFirstVisibleItemElement handles null _flatData', () => {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -533,18 +533,6 @@ suite('basic', () => {
 		assert.isUndefined(element._removeInstance());
 	});
 
-	test('getFirstVisibleItemElement calls _getInstanceByProperty', () => {
-		const spy = sinonSpy(element, '_getInstanceByProperty'),
-			first = element.getFirstVisibleItemElement();
-		sinonAssert.called(spy);
-		assert.isNotNull(first);
-		spy.restore();
-	});
-
-	test('getFirstVisibleItemElement handles null _flatData', () => {
-		element._flatData = null;
-		assert.isFalse(element.getFirstVisibleItemElement());
-	});
 
 	test('_dataChanged calls _forwardItemPath for item changes', () => {
 		const spy = sinonSpy(element, '_forwardItemPath');
@@ -645,5 +633,33 @@ suite('compare items function', () => {
 		element.data = [{ id: 0 }, { id: 5 }];
 		flushAsynchronousOperations(); // flush _render debouncer
 		assert.deepEqual(element.selectedItems, [{ id: 0 }]);
+	});
+});
+
+
+suite('getFirstVisibleItemElement', () => {
+	let element;
+	setup(async () => {
+		element = await fixture(basicHtmlFixture);
+		element._templatesObserver.flush();
+		element.data = new Array(200).fill().map((_, i) => ({
+			id: `id-${ i }`,
+			title: `Item ${ i }`,
+			value: i
+		}));
+		flushAsynchronousOperations();
+	});
+	test('getFirstVisibleItemElement calls _getInstanceByProperty', () => {
+		const spy = sinonSpy(element, '_getInstanceByProperty'),
+			first = element.getFirstVisibleItemElement();
+		sinonAssert.called(spy);
+		assert.isNotNull(first);
+		assert.isNotNull(first.offsetParent);
+		spy.restore();
+	});
+
+	test('getFirstVisibleItemElement handles null _flatData', () => {
+		element._flatData = null;
+		assert.isFalse(element.getFirstVisibleItemElement());
 	});
 });


### PR DESCRIPTION
If cosmoz-grouped-list is scrolled and iron-list or the template selector performs a re-render
getFirstVisibleItemElement might return a non visible item
This PR is mainly targetting cosmoz-omnitable header adjustment bugs.

Note: This also fixes hasRenderedData which incorrectly returns true when `_instances` contains a non visible instance (can happned if you scroll and change data).